### PR TITLE
make skipped() case insensitive

### DIFF
--- a/src/entities/SetupStep.ts
+++ b/src/entities/SetupStep.ts
@@ -16,7 +16,7 @@ export class SetupStep {
 	}
 
 	public skipped(response: Message | undefined): boolean {
-		return response && response.content === 'skip' ? true : false
+		return response && response.content.toLowerCase() === 'skip' ? true : false
 	}
 
 	public validate(response: Message | undefined): boolean {


### PR DESCRIPTION
Allow users to type `skip` in any case (skip, Skip, SKIP, etc)